### PR TITLE
Click on same atlas node again should reset the atalasNodeStore

### DIFF
--- a/src/composable/atlas-node-click-handler.ts
+++ b/src/composable/atlas-node-click-handler.ts
@@ -9,7 +9,6 @@ const detailsDrawerStore = useDetailsDrawerStore();
 const atlasNodeStore = useAtlasNodeStore();
 
 export function handleAtlasNodeClicked(atlasNode: AtlasNode) {
-    console.log(atlasNode)
     if (atlasMemoryNodeStore.atlasMemoryModeEnabled) {
         calculateAtlasMemoryPaths(atlasNode, atlasMemoryNodeStore.numberOfMemorySteps)
     } else {

--- a/src/composable/atlas-node-click-handler.ts
+++ b/src/composable/atlas-node-click-handler.ts
@@ -9,13 +9,14 @@ const detailsDrawerStore = useDetailsDrawerStore();
 const atlasNodeStore = useAtlasNodeStore();
 
 export function handleAtlasNodeClicked(atlasNode: AtlasNode) {
+    console.log(atlasNode)
     if (atlasMemoryNodeStore.atlasMemoryModeEnabled) {
         calculateAtlasMemoryPaths(atlasNode, atlasMemoryNodeStore.numberOfMemorySteps)
     } else {
         detailsDrawerStore.SET_DRAWER(true)
     }
     if (atlasNodeStore.selectedAtlasNode == atlasNode) {
-        atlasNodeStore.SET_SELECTED_ATLAS_NODE(null)
+        atlasNodeStore.RESET_SELECTED_ATLAS_NODE()
     } else {
         atlasNodeStore.SET_SELECTED_ATLAS_NODE(atlasNode)
     }

--- a/src/composable/atlas-node-click-handler.ts
+++ b/src/composable/atlas-node-click-handler.ts
@@ -14,5 +14,9 @@ export function handleAtlasNodeClicked(atlasNode: AtlasNode) {
     } else {
         detailsDrawerStore.SET_DRAWER(true)
     }
-    atlasNodeStore.SET_SELECTED_ATLAS_NODE(atlasNode)
+    if (atlasNodeStore.selectedAtlasNode == atlasNode) {
+        atlasNodeStore.SET_SELECTED_ATLAS_NODE(null)
+    } else {
+        atlasNodeStore.SET_SELECTED_ATLAS_NODE(atlasNode)
+    }
 }

--- a/src/store/AtlasNodeStore/index.ts
+++ b/src/store/AtlasNodeStore/index.ts
@@ -32,6 +32,10 @@ export const useAtlasNodeStore = defineStore("atlas-node", {
             this.selectedAtlasNode = selectedAtlasNode;
         },
 
+        RESET_SELECTED_ATLAS_NODE() {
+            this.selectedAtlasNode = null;
+        },
+
         SET_FILTERED_ATLAS_NODE_IDS(filteredAtlasNodeIds: Array<AtlasNode>) {
             this.filteredAtlasNodes = filteredAtlasNodeIds
         },


### PR DESCRIPTION
Add a new quality of life feature which enable user to close the information window on the right-hand side for an atlas node, simply double-click the node in the Atlas.