### PR TITLE
refactor: using webp bg image and changed ratios

### DIFF
--- a/src/components/DynamicAtlas.vue
+++ b/src/components/DynamicAtlas.vue
@@ -2,7 +2,7 @@
 import Konva from 'konva'
 import { onMounted, reactive, ref } from 'vue'
 import { useMouseInElement } from '@vueuse/core'
-import atlasBackgroundSource from '@/assets/atlas/maps/AtlasBackground.png'
+import atlasBackgroundSource from '@/assets/atlas/maps/Atlas.webp'
 import atlasMemorySource from '@/assets/atlas/memories/KiracMemoryItem.png'
 import mapBase from '@/assets/atlas/maps/Base.png'
 import uniqueMapList from '@/assets/atlas/maps/uniques/index.js'
@@ -124,13 +124,15 @@ function initAtlasCanvas() {
   })
   handleZoom(state)
 }
-const offsetX = 0 // 125
-const offsetY = 0 // 90
-const height = window.innerHeight - 48 - 78 // minus navbar and footer
-const width = window.innerWidth // minus filter drawer
-const currentScaleX = width / window.screen.width // Scaling things according to height
-const currentScaleY = height / window.screen.height // Scaling things according to height
+
 function initState() {
+  const offsetX = 0 // 125
+  const offsetY = 0 // 90
+  const height = window.innerHeight - 48 - 78 // minus navbar and footer
+  const width = window.innerWidth // minus filter drawer
+  const currentScaleX = window.screen.width / 1920 // Scaling things according to height
+  const currentScaleY = height / 1080 // Scaling things according to height
+
   state = {
     stage: undefined,
     currentScale: currentScaleY,
@@ -526,11 +528,11 @@ atlasMemoryNodeStore.$subscribe((mutation, state) => {
 function drawBackgroundImage(): Konva.Image {
   const atlasBackgroundImage = new Image()
   atlasBackgroundImage.src = atlasBackgroundSource
-  //   atlasBackgroundImage.width = window.screen.width * (1 / currentScaleX)
-  //   atlasBackgroundImage.height = window.screen.height * (1 / currentScaleY)
   const atlasBackgroundKonvaImage = new Konva.Image({
     id: 'atlas-background',
     image: atlasBackgroundImage,
+    scaleX: 0.46875, // webp image resolution to 1920x1080 scale
+    scaleY: 0.46875, // webp image resolution to 1920x1080 scale
   })
   atlasBackgroundImage.onload = function () {
     const image = backgroundGroup.findOne('#atlas-background')


### PR DESCRIPTION
Things should be more responsive for desktop
- Using webp for small image size
- Change ratios to they are based off the base of 1920x1080
- Scaled the bg image correctly

Still not sure if this is proper way, on 4k screen the bg img does seem a bit blurry but using the original in its original format just doesnt work with the map locations.